### PR TITLE
annotations show citation source

### DIFF
--- a/openai-assistant/test/chainlit_tests/streaming.py
+++ b/openai-assistant/test/chainlit_tests/streaming.py
@@ -5,6 +5,7 @@ and you'll see multiple runs and messages being passed through.
 
 """
 import logging
+import os
 
 import chainlit as cl
 from dotenv import load_dotenv
@@ -14,9 +15,9 @@ from utils.openai_utils import initialize_openai_client, get_playground_url
 
 logging.basicConfig(level=logging.INFO)
 
-load_dotenv(dotenv_path='../', override=True)
+load_dotenv(dotenv_path='../../.env', override=True)
 
-assistant_id = 'asst_2lanl1dvlTkCpOofxiPrHvzr'
+assistant_id = os.getenv('TEST_ASSISTANT_ID')
 
 
 @cl.on_chat_start

--- a/openai-assistant/test/test_annotations.py
+++ b/openai-assistant/test/test_annotations.py
@@ -3,14 +3,13 @@ import unittest
 
 from dotenv import load_dotenv
 
-from utils.annotations import OpenAIAdapter
 from fixture import message_with_citation, \
     message_no_citation, message_with_invalid_index, message_with_multiple_annotations_no_quotes, \
     message_with_multiple_annotations, message_with_no_quote
+from utils.annotations import OpenAIAdapter
 
 load_dotenv()
 logging.basicConfig(level=logging.INFO)
-
 
 annotations_fixtures = [message_with_citation,  # 1
                         message_with_invalid_index,  # 0
@@ -25,7 +24,7 @@ class NewTestAnnotations(unittest.IsolatedAsyncioTestCase):
 
     async def test_all_fixtures(self):
         results = []
-        expected_results = [1, 0, 0, 0, 3, 0]
+        expected_results = [1, 0, 0, 3, 3, 1]
         for message in annotations_fixtures:
             fixture = OpenAIAdapter(message)
 
@@ -50,7 +49,7 @@ class NewTestAnnotations(unittest.IsolatedAsyncioTestCase):
         await message.set_citations()
         message.set_elements()
         result = message.elements
-        self.assertEqual(len(result), 0)
+        self.assertEqual(len(result), 3)
 
         message = OpenAIAdapter(message_with_multiple_annotations)
         await message.set_citations()
@@ -89,4 +88,3 @@ class NewTestAnnotations(unittest.IsolatedAsyncioTestCase):
 
         result = OpenAIAdapter(message_with_citation).has_annotations()
         self.assertTrue(result)
-

--- a/openai-assistant/test/test_streaming_async.py
+++ b/openai-assistant/test/test_streaming_async.py
@@ -52,6 +52,7 @@ class TestStreaming(unittest.IsolatedAsyncioTestCase):
         ) as stream:
             await stream.until_done()
 
+    @unittest.skip('This test is out of date following V2 Event handling')
     @patch('chainlit.Message', new_callable=MagicMock)
     async def testMessageDelta(self, mock_cl_message):
         mock_cl_message.return_value.send = AsyncMock()

--- a/openai-assistant/test/test_thread_handler.py
+++ b/openai-assistant/test/test_thread_handler.py
@@ -1,0 +1,29 @@
+import logging
+
+import chainlit as cl
+from app.utils.annotations import OpenAIAdapter
+from app.utils.openai_utils import get_thread_messages, initialize_openai_client
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("chainlit")
+
+client = initialize_openai_client()
+
+
+@cl.on_chat_start
+async def on_chat_start():
+    messages = await get_thread_messages(client, 'thread_J05pHO7SIE0HWqQZJymAdo8Q')
+    logger.info(messages.data)
+    for thread_message in messages.data:
+        message = OpenAIAdapter(thread_message)
+        await message.set_citations()
+        cl_message = message.get_message()
+
+        logger.info(cl_message.elements)
+        await cl_message.send()
+
+
+if __name__ == "__main__":
+    from chainlit.cli import run_chainlit
+
+    run_chainlit(__file__)

--- a/openai-assistant/test/test_thread_handler.py
+++ b/openai-assistant/test/test_thread_handler.py
@@ -1,8 +1,8 @@
 import logging
 
 import chainlit as cl
-from app.utils.annotations import OpenAIAdapter
-from app.utils.openai_utils import get_thread_messages, initialize_openai_client
+from utils.annotations import OpenAIAdapter
+from utils.openai_utils import get_thread_messages, initialize_openai_client
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("chainlit")

--- a/openai-assistant/test/test_threads.py
+++ b/openai-assistant/test/test_threads.py
@@ -1,16 +1,15 @@
 import unittest
 
-from utils.openai_utils import initialize_openai_client
+from app.utils.openai_utils import initialize_openai_client
 
 
 @unittest.skip('Sanity check; needs new thread ID')
 class TestThreads(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
-        self.thread_id = "thread_PPecfP37eSXH14froEsJJCSr"
+        self.thread_id = "thread_J05pHO7SIE0HWqQZJymAdo8Q"
         self.client = initialize_openai_client('../.env')
 
     async def test_threads(self):
-
         response = await self.client.beta.threads.retrieve(self.thread_id)
         print(response)
 

--- a/openai-assistant/test/test_threads.py
+++ b/openai-assistant/test/test_threads.py
@@ -1,13 +1,13 @@
 import unittest
 
-from app.utils.openai_utils import initialize_openai_client
+from utils.openai_utils import initialize_openai_client
 
 
 @unittest.skip('Sanity check; needs new thread ID')
 class TestThreads(unittest.IsolatedAsyncioTestCase):
     def setUp(self):
         self.thread_id = "thread_J05pHO7SIE0HWqQZJymAdo8Q"
-        self.client = initialize_openai_client('../.env')
+        self.client = initialize_openai_client()
 
     async def test_threads(self):
         response = await self.client.beta.threads.retrieve(self.thread_id)

--- a/openai-assistant/utils/annotations.py
+++ b/openai-assistant/utils/annotations.py
@@ -79,6 +79,9 @@ class OpenAIAdapter:
         )
 
     def get_content(self) -> str:
+        """
+        Replace the annotation citation reference with an [n] type reference instead
+        """
         value: str = self.message.content[0].text.value
 
         for i, annotation in enumerate(self.annotations):
@@ -88,14 +91,11 @@ class OpenAIAdapter:
             # Replace the citation text with the citation reference
             # Since we're working backward, we don't need to adjust the start and end indices)
 
-            if self.has_quote(annotation):
-                value = (
-                        value[: annotation.start_index]
-                        + citation_ref
-                        + value[annotation.end_index:]
-                )
-            else:  # We've got a bug, OAI forgot to return the citation, so remove the reference
-                value = value[: annotation.start_index] + value[annotation.end_index:]
+            value = (
+                    value[: annotation.start_index]
+                    + citation_ref
+                    + value[annotation.end_index:]
+            )
 
         return value
 

--- a/openai-assistant/utils/annotations.py
+++ b/openai-assistant/utils/annotations.py
@@ -13,11 +13,10 @@ from openai.types import FileObject
 from openai.types.beta.threads import (
     Message as ThreadMessage
 )
-
 from openai.types.beta.threads.file_citation_annotation import FileCitation as TextAnnotationFileCitationFileCitation, \
     FileCitationAnnotation as TextAnnotationFileCitation
 
-from .openai_utils import initialize_openai_client
+from utils.openai_utils import initialize_openai_client
 
 
 class OpenAIAdapter:
@@ -26,7 +25,7 @@ class OpenAIAdapter:
     """
 
     def __init__(self, message: ThreadMessage) -> None:
-        self.client = initialize_openai_client("../../.env")
+        self.client = initialize_openai_client()
         self._id: str = message.id
         self.message: ThreadMessage = message
         # We're putting these in reverse order so we can work backward in get_content


### PR DESCRIPTION
Pulling files from prod repo and fixing. This refactors the file citation display. Since the models no longer return quotes separately, we need to at least display a footnote and filename reference. 

- **fix: annotations render citation source even if no quote**
- **fix: broken tests**
- **fix: render footnotes in message content if citation quote is missing**
