### PR TITLE
fix: throw exception if asst name is missing from ENV

### DIFF
--- a/openai_assistant/app.py
+++ b/openai_assistant/app.py
@@ -21,7 +21,8 @@ client = initialize_openai_client()
 logger = logging.getLogger("chainlit")
 
 ASSISTANT_NAME = os.getenv('ASSISTANT_NAME')
-
+if not ASSISTANT_NAME:
+    raise Exception("MISSING ASSISTANT NAME")
 
 # Uncomment for live deployments!
 # @cl.oauth_callback


### PR DESCRIPTION
Stop app on run if name is missing. 